### PR TITLE
media: radio: Fix building and loading the iris transport

### DIFF
--- a/drivers/media/radio/radio-iris-transport.c
+++ b/drivers/media/radio/radio-iris-transport.c
@@ -219,7 +219,11 @@ static void radio_hci_smd_deregister(void)
 	fmsmd_set = 0;
 }
 
-static int radio_hci_smd_init(void)
+#ifndef MODULE
+int radio_hci_smd_init(void)
+#else
+static int __init radio_hci_smd_init(void)
+#endif
 {
 	int ret;
 

--- a/drivers/media/radio/radio-iris.c
+++ b/drivers/media/radio/radio-iris.c
@@ -51,6 +51,7 @@ static char rt_ert_flag;
 static char formatting_dir;
 static unsigned char sig_blend = CTRL_ON;
 static DEFINE_MUTEX(iris_fm);
+static int transport_ready = -1;
 
 module_param(rds_buf, uint, 0);
 MODULE_PARM_DESC(rds_buf, "RDS buffer entries: *100*");
@@ -5467,6 +5468,15 @@ static const struct v4l2_ioctl_ops iris_ioctl_ops = {
 	.vidioc_g_ext_ctrls           = iris_vidioc_g_ext_ctrls,
 };
 
+#ifndef MODULE
+extern int radio_hci_smd_init(void);
+static int iris_fops_open(struct file *f) {
+	if (transport_ready < 0)
+		transport_ready = radio_hci_smd_init();
+	return transport_ready;
+}
+#endif
+
 static const struct v4l2_file_operations iris_fops = {
 	.owner = THIS_MODULE,
 	.unlocked_ioctl = video_ioctl2,
@@ -5474,6 +5484,9 @@ static const struct v4l2_file_operations iris_fops = {
 	.compat_ioctl32 = v4l2_compat_ioctl32,
 #endif
 	.release        = iris_fops_release,
+#ifndef MODULE
+	.open           = iris_fops_open,
+#endif
 };
 
 static struct video_device iris_viddev_template = {


### PR DESCRIPTION
Break the initialization dependency on module-load and tie it to
opening up the actual v4l device.

Change-Id: I12d5226e7e9b15d14cf62e2dc666612f4cb608f1
Signed-off-by: FireLord1 <firelord.xda@lineageos.org>